### PR TITLE
Replace shell 'timeout' with Python native timer for macOS support

### DIFF
--- a/tests/mycpu_plugin/riscof_mycpu.py
+++ b/tests/mycpu_plugin/riscof_mycpu.py
@@ -171,6 +171,7 @@ class mycpu(pluginTemplate):
 
             def timeout_handler():
                 logger.error(f"Simulation timed out after {timeout_sec} seconds! Killing process...")
+                proc.terminate()
                 proc.kill()
             
             timer = threading.Timer(timeout_sec, timeout_handler)


### PR DESCRIPTION
The GNU `timeout` command is not available by default on macOS, causing the RISCOF test runner to fail with a "command not found" error.

This commit replaces the shell-based `timeout 3600` command with a cross-platform Python implementation using `threading.Timer`. This ensures the simulation can still be terminated if it hangs, while maintaining compatibility across Linux and macOS environments.

CHANGE:
- Removed `timeout 3600` from the subprocess command string.
- Implemented `threading.Timer` to send SIGKILL to the SBT process upon timeout.
- Ensures compatibility with macOS and systems without GNU tools.